### PR TITLE
[#5] 상태바 스타일 적용

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -10,7 +10,8 @@
         <item name="colorSecondaryVariant">@color/main_light_blue</item>
         <item name="colorOnSecondary">@color/main_black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">true</item>
         <!-- Customize your theme here. -->
         <item name="android:colorBackground">@color/main_white</item>
     </style>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,7 +10,8 @@
         <item name="colorSecondaryVariant">@color/main_light_blue</item>
         <item name="colorOnSecondary">@color/main_black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">true</item>
         <!-- Customize your theme here. -->
         <item name="android:colorBackground">@color/main_white</item>
     </style>


### PR DESCRIPTION
### 내용
- status bar 스타일을 적용합니다.
  - 피그마의 여러 화면을 보니, status bar의 배경은 투명 색으로 지정하는 것이 좋아보입니다.
  - 배경을 투명 색으로 지정하면 상태 바의 기본 아이콘들이 보이지 않습니다. 이를 해결하기 위해 추가로 🔗 [android:windowLightStatusBar](https://developer.android.com/reference/android/R.attr#windowLightStatusBar) 속성을 true로 설정합니다.
  - 이 속성은 API level 23에서 추가된 속성이기 때문에, 본 PR의 베이스 브랜치는 🔗[feature/min-sdk-change](https://github.com/MoyeoRun/MoyeoRun_Android/pull/14) 입니다.

### 변경 전 VS 변경 후
|변경 전|변경 후|
|---|---|
||<img src="https://user-images.githubusercontent.com/31889335/159260669-93b2109d-7e77-44dd-9755-fe7fab843df4.png" width="300" />|