### PR TITLE
[#2] 디폴트 스타일 설정

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,4 +11,9 @@
     <color name="main_light_blue">#EEF4FF</color>
 
     <!-- extra colors -->
+
+    <!-- text colors -->
+    <color name="text_default_black">#333333</color>
+    <color name="text_gray">#828282</color>
+
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,5 +15,6 @@
     <!-- text colors -->
     <color name="text_default_black">#333333</color>
     <color name="text_gray">#828282</color>
+    <color name="text_hint_gray">#A9A9A9</color>
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -14,5 +14,9 @@
         <item name="android:windowLightStatusBar">true</item>
         <!-- Customize your theme here. -->
         <item name="android:colorBackground">@color/main_white</item>
+        <item name="android:textColor">@color/text_default_black</item>
+        <item name="android:editTextColor">@color/text_default_black</item>
+        <item name="android:textSize">18dp</item>
     </style>
+
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -14,8 +14,10 @@
         <item name="android:windowLightStatusBar">true</item>
         <!-- Customize your theme here. -->
         <item name="android:colorBackground">@color/main_white</item>
+        <!-- Text -->
         <item name="android:textColor">@color/text_default_black</item>
         <item name="android:editTextColor">@color/text_default_black</item>
+        <item name="android:textColorHint">@color/text_hint_gray</item>
         <item name="android:textSize">18dp</item>
     </style>
 


### PR DESCRIPTION
### 내용
- 기본 텍스트 컬러 추가
- 기본 텍스트 사이즈 추가
- 기본 텍스트 컬러를 추가합니다. 
  - 피그마 디자인 가이드를 보면, 대부분의 검정 텍스트가 `#333333` 로 작성되어 있습니다.
  - 이런 경우, 별도로 텍스트 컬러를 매번 지정하지 않도록, 테마에 적용합니다.
  - `android:textColor` 만 추가해서는 `EditText` 에는 적용되지 않기 때문에 `android:editTextColor` 속성도 적용합니다.
  - 힌트 컬러도 추가합니다.
  - __추후, EditText 배경 작업(#24)과 함께, 하나의 EditText 용 스타일로 묶어서 적용하면 좋을 것 같습니다.__
- 기본 텍스트 사이즈를 추가합니다. 

### 참고
- #2