### PR TITLE
[#11] 각종 편의 확장함수 추가 - DebounceClick

### DIFF
--- a/app/src/main/java/com/moyerun/moyeorun_android/common/extension/ViewExtension.kt
+++ b/app/src/main/java/com/moyerun/moyeorun_android/common/extension/ViewExtension.kt
@@ -1,0 +1,19 @@
+package com.moyerun.moyeorun_android.common.extension
+
+import android.view.View
+
+fun View.setOnDebounceClickListener(interval: Long = 1000L, action: (View?) -> Unit) {
+    val debounceClickListener = object : View.OnClickListener {
+        private var lastClickedMillis = 0L
+
+        override fun onClick(view: View?) {
+            val now = System.currentTimeMillis()
+            if (now - lastClickedMillis < interval) {
+                return
+            }
+            lastClickedMillis = now
+            action.invoke(view)
+        }
+    }
+    setOnClickListener(debounceClickListener)
+}


### PR DESCRIPTION
### 내용
- 기존 `setOnClickListener()`를 사용하면 중복 클릭이 발생할 수 있습니다. (Activity 중복 실행, API 중복 호출)
- 디바운스 처리를 위해 View 확장함수에 `setOnDebounceClickListener()`를 추가합니다.
- 앞으로 모든 클릭 처리는 해당 API 로만 작성하도록 약속합니다. (`setOnClickListener()` 사용 금지)

### 작업 사항
- 기본 interval 은 1초로 설정합니다.
- 특정 API 의 응답이 1초 보다 느릴 수 있는 경우에 유동적으로 interval 을 변경할 수 있습니다.

### 사용 예시
- 다음과 같이 코드를 작성합니다.
- 이미지는 연타했을 때 로그 시간을 확인한 겁니다.

#### 기본 사용 -> interval 1초
```kotlin
findViewById<TextView>(R.id.test).setOnDebounceClickListener {
  Lg.d("click")
}
```
<img width="300" src="https://user-images.githubusercontent.com/57310034/163153150-1a224737-8645-4a22-9b81-e27baa82490d.png"/>

#### interval 파라미터 사용 -> 2초로 설정한 경우
```kotlin
findViewById<TextView>(R.id.test).setOnDebounceClickListener(2000L) {
  Lg.d("click")
}
```
<img width="300" src="https://user-images.githubusercontent.com/57310034/163153595-3e5310ca-e7a5-443b-a2ec-c4e3b244e879.png" />

### 참고
- #11 