### PR TITLE
[#6] 커스텀 로그 추가 - Firebase 로깅

### DIFF
--- a/app/src/main/java/com/moyerun/moyeorun_android/common/Lg.kt
+++ b/app/src/main/java/com/moyerun/moyeorun_android/common/Lg.kt
@@ -31,17 +31,17 @@ object Lg {
     }
 
     fun fd(msg: String) {
-        Log.e(tag, msg)
+        Log.d(tag, msg)
         Firebase.crashlytics.recordMessage(LogLevel.Debug, msg)
     }
 
     fun fd(t: Throwable) {
-        Log.e(tag, Log.getStackTraceString(t))
+        Log.d(tag, Log.getStackTraceString(t))
         Firebase.crashlytics.recordException(LogLevel.Debug, t)
     }
 
     fun fd(msg: String, t: Throwable) {
-        Log.e(tag, Log.getStackTraceString(t))
+        Log.d(tag, Log.getStackTraceString(t))
         Firebase.crashlytics.recordException(LogLevel.Debug, msg, t)
     }
 
@@ -62,17 +62,17 @@ object Lg {
     }
 
     fun fw(msg: String) {
-        Log.e(tag, msg)
+        Log.w(tag, msg)
         Firebase.crashlytics.recordMessage(LogLevel.Warning, msg)
     }
 
     fun fw(t: Throwable) {
-        Log.e(tag, Log.getStackTraceString(t))
+        Log.w(tag, Log.getStackTraceString(t))
         Firebase.crashlytics.recordException(LogLevel.Warning, t)
     }
 
     fun fw(msg: String, t: Throwable) {
-        Log.e(tag, Log.getStackTraceString(t))
+        Log.w(tag, Log.getStackTraceString(t))
         Firebase.crashlytics.recordException(LogLevel.Warning, msg, t)
     }
 
@@ -93,17 +93,17 @@ object Lg {
     }
 
     fun fi(msg: String) {
-        Log.e(tag, msg)
+        Log.i(tag, msg)
         Firebase.crashlytics.recordMessage(LogLevel.Info, msg)
     }
 
     fun fi(t: Throwable) {
-        Log.e(tag, Log.getStackTraceString(t))
+        Log.i(tag, Log.getStackTraceString(t))
         Firebase.crashlytics.recordException(LogLevel.Info, t)
     }
 
     fun fi(msg: String, t: Throwable) {
-        Log.e(tag, Log.getStackTraceString(t))
+        Log.i(tag, Log.getStackTraceString(t))
         Firebase.crashlytics.recordException(LogLevel.Info, msg, t)
     }
 

--- a/app/src/main/java/com/moyerun/moyeorun_android/common/Lg.kt
+++ b/app/src/main/java/com/moyerun/moyeorun_android/common/Lg.kt
@@ -1,6 +1,9 @@
 package com.moyerun.moyeorun_android.common
 
 import android.util.Log
+import com.google.firebase.crashlytics.ktx.crashlytics
+import com.google.firebase.ktx.Firebase
+import com.moyerun.moyeorun_android.common.extension.*
 
 object Lg {
 
@@ -27,6 +30,21 @@ object Lg {
         Log.d(tag, Log.getStackTraceString(t))
     }
 
+    fun fd(msg: String) {
+        Log.e(tag, msg)
+        Firebase.crashlytics.recordMessage(LogLevel.Debug, msg)
+    }
+
+    fun fd(t: Throwable) {
+        Log.e(tag, Log.getStackTraceString(t))
+        Firebase.crashlytics.recordException(LogLevel.Debug, t)
+    }
+
+    fun fd(msg: String, t: Throwable) {
+        Log.e(tag, Log.getStackTraceString(t))
+        Firebase.crashlytics.recordException(LogLevel.Debug, msg, t)
+    }
+
     fun w(msg: String) {
         Log.w(tag, msg)
     }
@@ -41,6 +59,21 @@ object Lg {
 
     fun w(tag: String, t: Throwable) {
         Log.w(tag, t)
+    }
+
+    fun fw(msg: String) {
+        Log.e(tag, msg)
+        Firebase.crashlytics.recordMessage(LogLevel.Warning, msg)
+    }
+
+    fun fw(t: Throwable) {
+        Log.e(tag, Log.getStackTraceString(t))
+        Firebase.crashlytics.recordException(LogLevel.Warning, t)
+    }
+
+    fun fw(msg: String, t: Throwable) {
+        Log.e(tag, Log.getStackTraceString(t))
+        Firebase.crashlytics.recordException(LogLevel.Warning, msg, t)
     }
 
     fun i(msg: String) {
@@ -59,6 +92,21 @@ object Lg {
         Log.i(tag, Log.getStackTraceString(t))
     }
 
+    fun fi(msg: String) {
+        Log.e(tag, msg)
+        Firebase.crashlytics.recordMessage(LogLevel.Info, msg)
+    }
+
+    fun fi(t: Throwable) {
+        Log.e(tag, Log.getStackTraceString(t))
+        Firebase.crashlytics.recordException(LogLevel.Info, t)
+    }
+
+    fun fi(msg: String, t: Throwable) {
+        Log.e(tag, Log.getStackTraceString(t))
+        Firebase.crashlytics.recordException(LogLevel.Info, msg, t)
+    }
+
     fun e(msg: String) {
         Log.e(tag, msg)
     }
@@ -73,5 +121,20 @@ object Lg {
 
     fun e(tag: String, t: Throwable) {
         Log.e(tag, Log.getStackTraceString(t))
+    }
+
+    fun fe(msg: String) {
+        Log.e(tag, msg)
+        Firebase.crashlytics.recordMessage(LogLevel.Error, msg)
+    }
+
+    fun fe(t: Throwable) {
+        Log.e(tag, Log.getStackTraceString(t))
+        Firebase.crashlytics.recordException(LogLevel.Error, t)
+    }
+
+    fun fe(msg: String, t: Throwable) {
+        Log.e(tag, Log.getStackTraceString(t))
+        Firebase.crashlytics.recordException(LogLevel.Error, msg, t)
     }
 }

--- a/app/src/main/java/com/moyerun/moyeorun_android/common/extension/FirebaseExctension.kt
+++ b/app/src/main/java/com/moyerun/moyeorun_android/common/extension/FirebaseExctension.kt
@@ -1,0 +1,39 @@
+package com.moyerun.moyeorun_android.common.extension
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+
+fun FirebaseCrashlytics.recordMessage(logLevel: LogLevel, message: String) {
+    recordException(FirebaseLogException(logLevel, message))
+}
+
+fun FirebaseCrashlytics.recordException(logLevel: LogLevel, throwable: Throwable) {
+    recordException(FirebaseLogException(logLevel, throwable))
+}
+
+fun FirebaseCrashlytics.recordException(logLevel: LogLevel, message: String, throwable: Throwable) {
+    recordException(FirebaseLogException(logLevel, message, throwable))
+}
+
+/**
+ * Firebase 로깅 (recordException) 을 위해 사용하는 Exception
+ * 로깅하고자하는 Exception 은 cause 로 다루고, 로그 레벨과 메시지를 message 에 담는다.
+ */
+class FirebaseLogException : Exception {
+    constructor(logLevel: LogLevel, message: String) : super("$logLevel : $message")
+
+    constructor(logLevel: LogLevel, cause: Throwable) : super(logLevel.toString(), cause)
+
+    constructor(
+        logLevel: LogLevel,
+        message: String,
+        cause: Throwable
+    ) : super("$logLevel : $message", cause)
+}
+
+enum class LogLevel {
+    Info, Debug, Error, Warning;
+
+    override fun toString(): String {
+        return "LogLevel [${super.toString()}]"
+    }
+}


### PR DESCRIPTION
### 내용
- Firebase Crashlytics 에 로그를 남길 수 있도록 Lg 함수를 추가합니다.
- 일반적인 상황에서 발생해선 안되는 예외 및 예의주시하고 있는 예외들을 Firebase 에 기록해야 추후 대응하거나 재발 방지책을 고민할 수 있기 때문입니다.
- 이 외에도 기타 message 로그 등을 Firebase 에서 살펴볼 수 있도록 합니다.

### 작업 사항
- `FirebaseLogException` 클래스를 추가합니다.
  - Firebase Crashlytis 는 Exception 을 수집하기 때문입니다.
  - `log()` 함수도 있지만, Exception 이 발생하기 전 로그를 남기는 개념이라 요구사항에 적합하지 않습니다.
- `FirebaseCrashlytics` 의 확장함수를 추가합니다.
  - 로그 레벨과 로그로 남기고자 하는 메시지 및 예외를 FirebaseLogException 으로 wrapping 해서 `recordException()`을 호출합니다.

#### 사용방법
- `Lg.fd()`, `Lg.fe()` 등 "f" prefix 가 붙은 함수는 Firebase Crashlytics 에도 함께 로깅합니다. 로깅 방법은 동일합니다.
  - tag 는 지정할 수 없습니다. 메서드 많아져서 귀찮아서 .. 안쓸 것 같기도 하고 ..
- Firebase Crashlytics 대시보드에서 "심각하지 않음" 으로 필터링해서 이렇게 수집된 로그를 확인할 수 있습니다.

<img width="920" alt="image" src="https://user-images.githubusercontent.com/57310034/163952442-8e974581-e14d-42b4-8872-4328331e8f0b.png">  

- 위에 보시면 심각하지 않음 으로 분류된 것이 record 한 에러입니다.

<img width="926" alt="image" src="https://user-images.githubusercontent.com/57310034/163953076-5b9a6095-2b6e-4c21-9db4-f5503c90295a.png">  

- 메시지만 로깅한 경우에는 FirebaseExtension.kt 파일 안에서 Exception 클래스를 생성하기 때문에 사진처럼 두 개의 스택이 더 쌓입니다. 무시하고 아래 실제 에러가 발생한 위치를 보면 됩니다.
  - 개선 방법이 떠오르지 않네요.

### 참고
- #6
- [Firebase Crashlytics - 심각하지 않은 예외 보고](https://firebase.google.com/docs/crashlytics/customize-crash-reports?platform=android#log-excepts)