### PR TITLE
[#35] Jetpack Navigation 베이스 코드 작성

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,6 +73,7 @@ android {
 dependencies {
     def glide_version = '4.13.1'
     def retrofit_version = '2.9.0'
+    def navigation_version = "2.4.2"
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
@@ -101,4 +102,8 @@ dependencies {
 
     // Coroutine
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'
+
+    // Navigation
+    implementation "androidx.navigation:navigation-fragment-ktx:$navigation_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$navigation_version"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,7 +73,7 @@ android {
 dependencies {
     def glide_version = '4.13.1'
     def retrofit_version = '2.9.0'
-    def navigation_version = "2.4.2"
+    def navigation_version = '2.4.2'
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'

--- a/app/src/main/java/com/moyerun/moyeorun_android/MainActivity.kt
+++ b/app/src/main/java/com/moyerun/moyeorun_android/MainActivity.kt
@@ -2,10 +2,32 @@ package com.moyerun.moyeorun_android
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.navigation.NavController
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.ui.setupWithNavController
+import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.moyerun.moyeorun_android.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityMainBinding
+    private lateinit var navController: NavController
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        initBottomNavigation(binding.bottomNav)
+    }
+
+    private fun initBottomNavigation(bottomView: BottomNavigationView) {
+        val navHostFragment = supportFragmentManager.findFragmentById(
+            R.id.nav_host_fragment_container
+        ) as NavHostFragment
+
+        navController = navHostFragment.findNavController()
+        bottomView.setupWithNavController(navController)
     }
 }

--- a/app/src/main/java/com/moyerun/moyeorun_android/home/HomeFragment.kt
+++ b/app/src/main/java/com/moyerun/moyeorun_android/home/HomeFragment.kt
@@ -1,0 +1,13 @@
+package com.moyerun.moyeorun_android.home
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.View
+import com.moyerun.moyeorun_android.R
+
+class HomeFragment : Fragment(R.layout.fragment_home) {
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+    }
+}

--- a/app/src/main/java/com/moyerun/moyeorun_android/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/moyerun/moyeorun_android/profile/ProfileFragment.kt
@@ -1,0 +1,13 @@
+package com.moyerun.moyeorun_android.profile
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.View
+import com.moyerun.moyeorun_android.R
+
+class ProfileFragment : Fragment(R.layout.fragment_profile) {
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+    }
+}

--- a/app/src/main/java/com/moyerun/moyeorun_android/record/RecordFragment.kt
+++ b/app/src/main/java/com/moyerun/moyeorun_android/record/RecordFragment.kt
@@ -1,0 +1,13 @@
+package com.moyerun.moyeorun_android.record
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.View
+import com.moyerun.moyeorun_android.R
+
+class RecordFragment : Fragment(R.layout.fragment_record) {
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+    }
+}

--- a/app/src/main/java/com/moyerun/moyeorun_android/search/SearchFragment.kt
+++ b/app/src/main/java/com/moyerun/moyeorun_android/search/SearchFragment.kt
@@ -1,0 +1,13 @@
+package com.moyerun.moyeorun_android.search
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.View
+import com.moyerun.moyeorun_android.R
+
+class SearchFragment : Fragment(R.layout.fragment_search) {
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+    }
+}

--- a/app/src/main/res/drawable/ic_home.xml
+++ b/app/src/main/res/drawable/ic_home.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,23 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     tools:context=".MainActivity">
 
     <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/nav_host_container"
-        android:layout_width="match_parent"
+        android:id="@+id/nav_host_fragment_container"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_weight="1"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottom_nav"
+        app:layout_constraintEnd_toEndOf="parent"
         app:defaultNavHost="true"
         app:navGraph="@navigation/main_nav_graph" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_nav"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:menu="@menu/bottom_nav_menu" />
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context=".MainActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/nav_host_container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/main_nav_graph" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_nav"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:menu="@menu/bottom_nav_menu" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".home.HomeFragment">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="홈" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".profile.ProfileFragment">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="프로필" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_record.xml
+++ b/app/src/main/res/layout/fragment_record.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".record.RecordFragment">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="기록" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".search.SearchFragment">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="검색" />
+
+</FrameLayout>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -2,19 +2,19 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- TODO : (초희) 각 아이템의 아이콘을 피그마 디자인으로 변경해야 합니다. -->
     <item
-        android:id="@+id/home"
+        android:id="@+id/home_nav_graph"
         android:icon="@drawable/ic_home"
         android:title="Home" />
     <item
-        android:id="@+id/search"
+        android:id="@+id/search_nav_graph"
         android:icon="@drawable/ic_home"
         android:title="Search" />
     <item
-        android:id="@+id/record"
+        android:id="@+id/record_nav_graph"
         android:icon="@drawable/ic_home"
         android:title="Record" />
     <item
-        android:id="@+id/profile"
+        android:id="@+id/profile_nav_graph"
         android:icon="@drawable/ic_home"
         android:title="Profile" />
 </menu>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- TODO : (초희) 각 아이템의 아이콘을 피그마 디자인으로 변경해야 합니다. -->
+    <item
+        android:id="@+id/home"
+        android:icon="@drawable/ic_home"
+        android:title="Home" />
+    <item
+        android:id="@+id/search"
+        android:icon="@drawable/ic_home"
+        android:title="Search" />
+    <item
+        android:id="@+id/record"
+        android:icon="@drawable/ic_home"
+        android:title="Record" />
+    <item
+        android:id="@+id/profile"
+        android:icon="@drawable/ic_home"
+        android:title="Profile" />
+</menu>

--- a/app/src/main/res/navigation/home_nav_graph.xml
+++ b/app/src/main/res/navigation/home_nav_graph.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/home_nav_graph"
+    app:startDestination="@id/homeFragment">
+
+    <fragment
+        android:id="@+id/homeFragment"
+        android:name="com.moyerun.moyeorun_android.home.HomeFragment"
+        android:label="Home"
+        tools:layout="@layout/fragment_home" />
+
+</navigation>

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/main_nav_graph">
+
+</navigation>

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/main_nav_graph">
+    android:id="@+id/main_nav_graph"
+    app:startDestination="@id/home_nav_graph">
+
+    <include app:graph="@navigation/home_nav_graph" />
+    <include app:graph="@navigation/search_nav_graph" />
+    <include app:graph="@navigation/record_nav_graph" />
+    <include app:graph="@navigation/profile_nav_graph" />
 
 </navigation>

--- a/app/src/main/res/navigation/profile_nav_graph.xml
+++ b/app/src/main/res/navigation/profile_nav_graph.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/profile_nav_graph"
+    app:startDestination="@id/profileFragment">
+
+    <fragment
+        android:id="@+id/profileFragment"
+        android:name="com.moyerun.moyeorun_android.profile.ProfileFragment"
+        android:label="Profile"
+        tools:layout="@layout/fragment_profile" />
+
+</navigation>

--- a/app/src/main/res/navigation/record_nav_graph.xml
+++ b/app/src/main/res/navigation/record_nav_graph.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/record_nav_graph"
+    app:startDestination="@id/recordFragment">
+
+    <fragment
+        android:id="@+id/recordFragment"
+        android:name="com.moyerun.moyeorun_android.record.RecordFragment"
+        android:label="Record"
+        tools:layout="@layout/fragment_record" />
+
+</navigation>

--- a/app/src/main/res/navigation/search_nav_graph.xml
+++ b/app/src/main/res/navigation/search_nav_graph.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/search_nav_graph"
+    app:startDestination="@id/searchFragment">
+
+    <fragment
+        android:id="@+id/searchFragment"
+        android:name="com.moyerun.moyeorun_android.search.SearchFragment"
+        android:label="Search"
+        tools:layout="@layout/fragment_search" />
+
+</navigation>


### PR DESCRIPTION
### 내용
- (1) Jetpack Navigation 적용 
  - Jetpack Navigation 을 적용하기로 논의했었어서
  - 적용했습니다. (구조를 잡기 위한 베이스 코드)
- (2) Bottom Navigation 컴포넌트 적용
  - 피그마 UI 를 보면 바텀 네비게이션이 있기 때문에 
  - Material Design에서 제공해주는 BottomNavigation 컴포넌트를 사용하여 구현했습니다.
- 전체적으로 github android repo의 [architecture-components-samples/NavigationAdvancedSample 프로젝트](https://github.com/android/architecture-components-samples/tree/main/NavigationAdvancedSample) 오픈 소스를 참고했습니다.

### 작업 사항
- (1) 패키지 구조
  - 로그인 쪽 작업을 슬쩍 훔쳐보니 기능 단위로 패키지를 나누고 있는 것 같아서 같은 방식으로 패키지 생성했습니다.
~~~
home
ㄴHomeFragment
search
ㄴSearchFragment
...
~~~
- (2) navigation 리소스 파일 생성
  - `main_nav_graph.xml` : 메인 그래프
  - 홈 / 검색 / 기록 / 프로필 그래프는 메인 그래프와 분리하여 메인 그래프에 include 했습니다.
    - 피그마 참고하니, 홈 / 검색 / 기록 / 프로필 화면 각각에서 탐색 그래프가 나올 수 있을 것 같아 분리했습니다.

### 변경 전 VS 변경 후
|변경 전|변경 후|
|---|---|
|<img src="" width="300" />|<img src="https://user-images.githubusercontent.com/31889335/169302312-601c0a62-fe88-40d6-9a74-3057e8d24871.gif" width="300" />|

### 참고
- BottomNavigation 아이콘 및 타이틀은 아직 적용 전 입니다.