### PR TITLE
[#17] 통신을 위한 네트워크 관련 베이스 코드 작성 - 컨버터 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,6 +104,7 @@ dependencies {
     // Retrofit2
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
+    implementation "com.squareup.okhttp3:okhttp:4.10.0"
 
     // Coroutine
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'

--- a/app/src/main/java/com/moyerun/moyeorun_android/network/MoyeorunJsonConverterFactory.kt
+++ b/app/src/main/java/com/moyerun/moyeorun_android/network/MoyeorunJsonConverterFactory.kt
@@ -1,0 +1,88 @@
+package com.moyerun.moyeorun_android.network
+
+import com.google.gson.Gson
+import com.google.gson.TypeAdapter
+import com.google.gson.reflect.TypeToken
+import com.moyerun.moyeorun_android.network.api.Success
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.ResponseBody
+import okio.Buffer
+import retrofit2.Converter
+import retrofit2.Retrofit
+import java.io.IOException
+import java.io.OutputStreamWriter
+import java.lang.reflect.Type
+import java.nio.charset.Charset
+
+class MoyeorunJsonConverterFactory private constructor(
+    private val gson: Gson
+) : Converter.Factory() {
+
+    override fun responseBodyConverter(
+        type: Type,
+        annotations: Array<out Annotation>,
+        retrofit: Retrofit
+    ): Converter<ResponseBody, *> {
+        val adapter = gson.getAdapter(TypeToken.get(type))
+        return MoyeorunResponseBodyConverter(gson, adapter)
+    }
+
+    override fun requestBodyConverter(
+        type: Type,
+        parameterAnnotations: Array<out Annotation>,
+        methodAnnotations: Array<out Annotation>,
+        retrofit: Retrofit
+    ): Converter<*, RequestBody> {
+        val adapter = gson.getAdapter(TypeToken.get(type))
+        return MoyeorunRequestBodyConverter(gson, adapter)
+    }
+
+    companion object {
+        fun create(): MoyeorunJsonConverterFactory {
+            return MoyeorunJsonConverterFactory(Gson())
+        }
+    }
+
+    class MoyeorunResponseBodyConverter<T>(
+        private val gson: Gson,
+        private val adapter: TypeAdapter<T>
+    ) : Converter<ResponseBody, T> {
+
+        override fun convert(value: ResponseBody): T? {
+            val jsonReader = gson.newJsonReader(value.charStream())
+            try {
+                val result: Success<T> = gson.fromJson(jsonReader, Success::class.java)
+                val data = gson.toJson(result.data)
+                return adapter.fromJson(data)
+            } catch (e: Exception) {
+                throw IOException(e)
+            } finally {
+                value.close()
+            }
+        }
+    }
+
+    class MoyeorunRequestBodyConverter<T>(
+        private val gson: Gson,
+        private val adapter: TypeAdapter<T>
+    ): Converter<T, RequestBody> {
+
+        @Throws(IOException::class)
+        override fun convert(value: T): RequestBody {
+            val buffer = Buffer()
+            val writer = OutputStreamWriter(buffer.outputStream(), UTF_8)
+            val jsonWriter = gson.newJsonWriter(writer)
+            adapter.write(jsonWriter, value)
+            jsonWriter.close()
+            return buffer.readByteString().toRequestBody(MEDIA_TYPE)
+        }
+
+        companion object {
+            private val MEDIA_TYPE: MediaType = "application/json; charset=UTF-8".toMediaType()
+            private val UTF_8 = Charset.forName("UTF-8")
+        }
+    }
+}

--- a/app/src/main/java/com/moyerun/moyeorun_android/network/calladapter/ApiResultCall.kt
+++ b/app/src/main/java/com/moyerun/moyeorun_android/network/calladapter/ApiResultCall.kt
@@ -14,7 +14,7 @@ class ApiResultCall<S>(
     override fun enqueue(callback: Callback<ApiResult<S>>) {
         delegate.enqueue(object : Callback<S> {
             override fun onResponse(call: Call<S>, response: Response<S>) {
-                val requestUrl = delegate.request().url().toString()
+                val requestUrl = delegate.request().url.toString()
 
                 // status code 200번대.
                 if (response.isSuccessful) {
@@ -76,7 +76,7 @@ class ApiResultCall<S>(
                     Response.success(
                         ApiResult.Failure(
                             NetworkException(
-                                call.request().url().toString(),
+                                call.request().url.toString(),
                                 throwable
                             )
                         )

--- a/app/src/main/java/com/moyerun/moyeorun_android/network/client/Retrofit.kt
+++ b/app/src/main/java/com/moyerun/moyeorun_android/network/client/Retrofit.kt
@@ -1,17 +1,17 @@
 package com.moyerun.moyeorun_android.network.client
 
 import com.moyerun.moyeorun_android.BuildConfig
-import com.moyerun.moyeorun_android.network.calladapter.ApiResultCallAdapterFactory
+import com.moyerun.moyeorun_android.network.MoyeorunJsonConverterFactory
 import com.moyerun.moyeorun_android.network.api.ApiService
+import com.moyerun.moyeorun_android.network.calladapter.ApiResultCallAdapterFactory
 import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
 
 private const val BASE_URL = BuildConfig.BASE_URL
 
 val retrofit: Retrofit = Retrofit.Builder()
     .baseUrl(BASE_URL)
     .addCallAdapterFactory(ApiResultCallAdapterFactory())
-    .addConverterFactory(GsonConverterFactory.create())
+    .addConverterFactory(MoyeorunJsonConverterFactory.create())
     .build()
 
 val apiService: ApiService = retrofit.create(ApiService::class.java)


### PR DESCRIPTION
### 내용
- 서버 응답에 맞도록 json 을 파싱하는 커스텀 ResponseBodyConverter 를 추가합니다.
- 응답을 Success 클래스로 감싸지 않고 payload 에 해당하는 데이터만을 꺼내 반환하도록 합니다.

### 작업 사항
- 위 내용을 구현하는 MoyeorunResponseBodyConverter 를 작성합니다.
  - Json 을 파싱해서 자바(코틀린)객체로 매핑합니다.
- 반대의 동작을 하는 MoyeorunRequestBodyConverter 를 작성합니다.
  - 별도로 해당 과정을 수정할 필요가 없으므로 GsonRequestBodyConverter 와 동일하게 작성합니다.
- 이 둘을 묶는 MoyeorunJsonConverterFactory 를 작성하여 Retrofit 생성 시 적용하도록 합니다.
- okhttp3 버전을 올립니다.
  - 멀티파트 관련 최신 변경 사항이 있어서 적용하고자 올렸습니다.
  - 이로 인해 request url 을 반환하는 함수가 프로퍼티로 변경되어 이부분 수정합니다.